### PR TITLE
fix: remove password strength validation when updating password

### DIFF
--- a/libs/extensions/src/dtos/authDto/change-password.dto.ts
+++ b/libs/extensions/src/dtos/authDto/change-password.dto.ts
@@ -1,6 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Service } from '@rumsan/sdk/enums';
-import { IsEnum, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
 
 export class ChangePasswordDto {
   @ApiProperty({
@@ -42,4 +49,15 @@ export class ChangePasswordDto {
   @IsEnum(Service)
   @IsNotEmpty()
   service: Service;
+
+  @ApiProperty({
+    example: false,
+    description:
+      'If true, skips password strength validation (min length, uppercase, lowercase, digit, special character checks). Password confirmation matching is still enforced. Defaults to false.',
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  bypassPasswordValidation?: boolean;
 }

--- a/libs/extensions/src/dtos/authDto/reset-password.dto.ts
+++ b/libs/extensions/src/dtos/authDto/reset-password.dto.ts
@@ -1,8 +1,10 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Service } from '@rumsan/sdk/enums';
 import {
+  IsBoolean,
   IsEnum,
   IsNotEmpty,
+  IsOptional,
   IsString,
   MinLength,
 } from 'class-validator';
@@ -55,4 +57,15 @@ export class ResetPasswordDto {
   @IsEnum(Service)
   @IsNotEmpty()
   service: Service;
+
+  @ApiProperty({
+    example: false,
+    description:
+      'If true, skips password strength validation (min length, uppercase, lowercase, digit, special character checks). Password confirmation matching is still enforced. Defaults to false.',
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  bypassPasswordValidation?: boolean;
 }

--- a/libs/extensions/src/dtos/authDto/set-password.dto.ts
+++ b/libs/extensions/src/dtos/authDto/set-password.dto.ts
@@ -1,6 +1,13 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { Service } from '@rumsan/sdk/enums';
-import { IsEnum, IsNotEmpty, IsString, MinLength } from 'class-validator';
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
 
 export class SetPasswordDto {
   @ApiProperty({
@@ -32,4 +39,15 @@ export class SetPasswordDto {
   @IsEnum(Service)
   @IsNotEmpty()
   service: Service;
+
+  @ApiProperty({
+    example: false,
+    description:
+      'If true, skips password strength validation (min length, uppercase, lowercase, digit, special character checks). Password confirmation matching is still enforced. Defaults to false.',
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  bypassPasswordValidation?: boolean;
 }

--- a/libs/user/src/lib/auths/auths.controller.ts
+++ b/libs/user/src/lib/auths/auths.controller.ts
@@ -100,13 +100,7 @@ export class AuthsController {
     @CurrentUser() user: CurrentUserInterface,
     @Body() dto: ChangePasswordDto,
   ) {
-    return this.authService.updatePassword(
-      user.id,
-      dto.oldPassword,
-      dto.newPassword,
-      dto.confirmPassword,
-      dto.service,
-    );
+    return this.authService.updatePassword(user.id, dto);
   }
 
   @Post('password/reset')

--- a/libs/user/src/lib/auths/auths.service.ts
+++ b/libs/user/src/lib/auths/auths.service.ts
@@ -12,6 +12,7 @@ import { JwtService } from '@nestjs/jwt';
 import { AuthSession, User } from '@prisma/client';
 import {
   ChallengeDto,
+  ChangePasswordDto,
   CreateServiceClientDto,
   OtpDto,
   OtpLoginDto,
@@ -597,11 +598,11 @@ export class AuthsService {
   }
 
   /**
-   * Set password for a user (first time)
+   * Validate password strength using configurable requirements.
+   * Throws ForbiddenException when the password does not meet the policy.
    */
-  async setPassword(userId: number, dto: SetPasswordDto) {
-    // Validate password strength
-    const validation = validatePasswordStrength(dto.password, {
+  private assertPasswordStrength(password: string): void {
+    const validation = validatePasswordStrength(password, {
       minLength: this.config.get<number>('PASSWORD_MIN_LENGTH') || 8,
       requireUppercase:
         this.config.get<boolean>('PASSWORD_REQUIRE_UPPERCASE') ?? true,
@@ -616,6 +617,15 @@ export class AuthsService {
       throw new ForbiddenException(
         `Password too weak: ${validation.errors.join(', ')}`,
       );
+    }
+  }
+
+  /**
+   * Set password for a user (first time)
+   */
+  async setPassword(userId: number, dto: SetPasswordDto) {
+    if (!dto.bypassPasswordValidation) {
+      this.assertPasswordStrength(dto.password);
     }
 
     // Check password confirmation
@@ -658,13 +668,9 @@ export class AuthsService {
   /**
    * Update existing password
    */
-  async updatePassword(
-    userId: number,
-    oldPassword: string,
-    newPassword: string,
-    confirmPassword: string,
-    service: Service,
-  ) {
+  async updatePassword(userId: number, dto: ChangePasswordDto) {
+    const { oldPassword, newPassword, confirmPassword, service } = dto;
+
     // Find auth record
     const auth = await this.prisma.auth.findFirst({
       where: {
@@ -686,26 +692,10 @@ export class AuthsService {
     if (!isOldPasswordValid) {
       throw new UnauthorizedException('Current password is incorrect');
     }
-    
-    //Password strength validation is not required for now as per the client's requirement.
 
-    // Validate new password strength
-    // const validation = validatePasswordStrength(newPassword, {
-    //   minLength: this.config.get<number>('PASSWORD_MIN_LENGTH') || 8,
-    //   requireUppercase:
-    //     this.config.get<boolean>('PASSWORD_REQUIRE_UPPERCASE') ?? true,
-    //   requireLowercase:
-    //     this.config.get<boolean>('PASSWORD_REQUIRE_LOWERCASE') ?? true,
-    //   requireDigit: this.config.get<boolean>('PASSWORD_REQUIRE_DIGIT') ?? true,
-    //   requireSpecial:
-    //     this.config.get<boolean>('PASSWORD_REQUIRE_SPECIAL') ?? true,
-    // });
-
-    // if (!validation.isValid) {
-    //   throw new ForbiddenException(
-    //     `Password too weak: ${validation.errors.join(', ')}`,
-    //   );
-    // }
+    if (!dto.bypassPasswordValidation) {
+      this.assertPasswordStrength(newPassword);
+    }
 
     // Check confirmation
     if (newPassword !== confirmPassword) {
@@ -753,21 +743,8 @@ export class AuthsService {
     }
 
     // Validate new password
-    const validation = validatePasswordStrength(dto.newPassword, {
-      minLength: this.config.get<number>('PASSWORD_MIN_LENGTH') || 8,
-      requireUppercase:
-        this.config.get<boolean>('PASSWORD_REQUIRE_UPPERCASE') ?? true,
-      requireLowercase:
-        this.config.get<boolean>('PASSWORD_REQUIRE_LOWERCASE') ?? true,
-      requireDigit: this.config.get<boolean>('PASSWORD_REQUIRE_DIGIT') ?? true,
-      requireSpecial:
-        this.config.get<boolean>('PASSWORD_REQUIRE_SPECIAL') ?? true,
-    });
-
-    if (!validation.isValid) {
-      throw new ForbiddenException(
-        `Password too weak: ${validation.errors.join(', ')}`,
-      );
+    if (!dto.bypassPasswordValidation) {
+      this.assertPasswordStrength(dto.newPassword);
     }
 
     // Check confirmation

--- a/libs/user/src/lib/auths/auths.service.ts
+++ b/libs/user/src/lib/auths/auths.service.ts
@@ -686,24 +686,26 @@ export class AuthsService {
     if (!isOldPasswordValid) {
       throw new UnauthorizedException('Current password is incorrect');
     }
+    
+    //Password strength validation is not required for now as per the client's requirement.
 
     // Validate new password strength
-    const validation = validatePasswordStrength(newPassword, {
-      minLength: this.config.get<number>('PASSWORD_MIN_LENGTH') || 8,
-      requireUppercase:
-        this.config.get<boolean>('PASSWORD_REQUIRE_UPPERCASE') ?? true,
-      requireLowercase:
-        this.config.get<boolean>('PASSWORD_REQUIRE_LOWERCASE') ?? true,
-      requireDigit: this.config.get<boolean>('PASSWORD_REQUIRE_DIGIT') ?? true,
-      requireSpecial:
-        this.config.get<boolean>('PASSWORD_REQUIRE_SPECIAL') ?? true,
-    });
+    // const validation = validatePasswordStrength(newPassword, {
+    //   minLength: this.config.get<number>('PASSWORD_MIN_LENGTH') || 8,
+    //   requireUppercase:
+    //     this.config.get<boolean>('PASSWORD_REQUIRE_UPPERCASE') ?? true,
+    //   requireLowercase:
+    //     this.config.get<boolean>('PASSWORD_REQUIRE_LOWERCASE') ?? true,
+    //   requireDigit: this.config.get<boolean>('PASSWORD_REQUIRE_DIGIT') ?? true,
+    //   requireSpecial:
+    //     this.config.get<boolean>('PASSWORD_REQUIRE_SPECIAL') ?? true,
+    // });
 
-    if (!validation.isValid) {
-      throw new ForbiddenException(
-        `Password too weak: ${validation.errors.join(', ')}`,
-      );
-    }
+    // if (!validation.isValid) {
+    //   throw new ForbiddenException(
+    //     `Password too weak: ${validation.errors.join(', ')}`,
+    //   );
+    // }
 
     // Check confirmation
     if (newPassword !== confirmPassword) {

--- a/libs/user/src/lib/signups/dto/signup-password.dto.ts
+++ b/libs/user/src/lib/signups/dto/signup-password.dto.ts
@@ -2,6 +2,7 @@ import { ApiProperty } from '@nestjs/swagger';
 import { IsFlexiblePhone, IsUsername } from '@rumsan/extensions/decorators';
 import { Service } from '@rumsan/sdk/enums';
 import {
+  IsBoolean,
   IsEmail,
   IsEnum,
   IsNotEmpty,
@@ -76,4 +77,15 @@ export class SignupPasswordDto {
   @IsEnum(Service)
   @IsNotEmpty()
   service: Service;
+
+  @ApiProperty({
+    example: false,
+    description:
+      'If true, skips password strength validation (min length, uppercase, lowercase, digit, special character checks). Password confirmation matching is still enforced. Defaults to false.',
+    required: false,
+    default: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  bypassPasswordValidation?: boolean;
 }

--- a/libs/user/src/lib/signups/signups.service.ts
+++ b/libs/user/src/lib/signups/signups.service.ts
@@ -37,24 +37,10 @@ export class SignupsService {
   ) {
     // Validate password signup
     if (dto instanceof SignupPasswordDto) {
-      // const { validatePasswordStrength } = await import(
-      //   '../utils/password.utils'
-      // );
-
       // Check password confirmation
       if (dto.password !== dto.confirmPassword) {
         throw new Error('Passwords do not match');
       }
-
-      // Validate password strength
-      // const validation = validatePasswordStrength(dto.password);
-      // if (!validation.isValid) {
-      //   console.log(validation, 'password validation result');
-      //   console.log(validation.isValid, 'is valid');
-      //   throw new Error(`Password too weak: ${validation.errors.join(', ')}`);
-      // }
-
-      // console.log(validation, 'password validation result');
     }
 
     let authIdentifier: { service: Service; serviceId: string };
@@ -161,7 +147,13 @@ export class SignupsService {
 
     try {
       const signupData: any = signup.data;
-      const { password, confirmPassword, service, ...userDataRaw } = signupData;
+      const {
+        password,
+        confirmPassword,
+        service,
+        bypassPasswordValidation,
+        ...userDataRaw
+      } = signupData;
       const userData: CreateUserDto = userDataRaw;
 
       //Reusable callback (single definition)
@@ -187,22 +179,14 @@ export class SignupsService {
 
       //PASSWORD HANDLING
       if (password) {
-        const { hashPassword, validatePasswordStrength } = await import(
-          '../utils/password.utils'
-        );
+        const { hashPassword } = await import('../utils/password.utils');
 
-        // Skip validation for USERNAME
-        if (service !== Service.USERNAME) {
-          const validation = validatePasswordStrength(password);
-          if (!validation.isValid) {
-            throw new Error(
-              `Password too weak: ${validation.errors.join(', ')}`,
-            );
-          }
+        if (!bypassPasswordValidation) {
+          await this.assertPasswordStrength(password);
+        }
 
-          if (password !== confirmPassword) {
-            throw new Error('Passwords do not match');
-          }
+        if (password !== confirmPassword) {
+          throw new Error('Passwords do not match');
         }
 
         const passwordHash = await hashPassword(password);
@@ -244,6 +228,20 @@ export class SignupsService {
           rejectedReason,
         },
       });
+    }
+  }
+
+  /**
+   * Validate password strength using default requirements.
+   * Throws when the password does not meet the policy.
+   */
+  private async assertPasswordStrength(password: string): Promise<void> {
+    const { validatePasswordStrength } = await import(
+      '../utils/password.utils'
+    );
+    const validation = validatePasswordStrength(password);
+    if (!validation.isValid) {
+      throw new Error(`Password too weak: ${validation.errors.join(', ')}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Added bypassPasswordValidation (default false) to the password DTOs (set/change/reset/signup).
- Re-enabled the strength check in updatePassword (was fully commented out) — now skippable only via the flag.
- Extracted the repeated validation logic into a shared assertPasswordStrength helper in AuthsService and SignupsService.
- Removed the old implicit "skip for USERNAME service" behavior in signup approval — bypass flag is now the only way to skip.